### PR TITLE
Retry async query of Profile Manager when it's not ready

### DIFF
--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
@@ -73,6 +73,11 @@ class DIProfileManagerCommand extends DICommandBase {
             {
                 String errorMessage = "Error when trying to retrieve ProfileManager: " + getResultCode(statusData.getResult());
                 logMessage(errorMessage, EMessageType.ERROR);
+
+                // Timed out, try again
+                if (statusData.getResult() == EMDKResults.STATUS_CODE.FEATURE_NOT_READY_TO_USE) {
+                    onEMDKManagerRetrieved(mEMDKManager);
+                }
             }
         }
     };
@@ -96,7 +101,7 @@ class DIProfileManagerCommand extends DICommandBase {
     public DIProfileManagerCommand(Context aContext) {
         super(aContext);
         mSettings = new DICommandBaseSettings(){{
-           mTimeOutMS = 20000;
+           mTimeOutMS = 120000;
            mEnableTimeOutMechanism = true;
            mCommandId = "DWProfileManagerCommand";
         }};


### PR DESCRIPTION
Retry async whery of Profile Manager when we get the FEATURE_NOT_READY_TO_USE response. Also lengthen the timeout used in the DICommandBaseSettings object - this was way too short. If the timeout callback fires during an async call for the profile, the wait never succeeds.

There's a separate issue with waitForEMDK not covered by this PR. That method looks non-functional. The only times it's called is when initializeEMDK fails to make the getEMDKManager call, but subsequent attempts for the wait method to call initializeEMDK will return immediately because bInitializing is always true in that situation. Even if the wait loop was functional, the really short timeout in DICommandBaseSettings compared to MAX_EMDK_TIMEOUT_IN_MS would shut down everything that the loop is waiting for.